### PR TITLE
Verbose level for logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 project(proxy)
 
-set(CMAKE_C_FLAGS_DEBUG "-Wall -Wextra -g")
+set(CMAKE_C_FLAGS_DEBUG "-Wall -DVERBOSE -Wextra -g")
 set(CMAKE_C_FLAGS_RELEASE "-Wall -Wextra -O3 -DNDEBUG")
 
 # Enet Module

--- a/include/utils/verbose.h
+++ b/include/utils/verbose.h
@@ -1,0 +1,10 @@
+#ifdef VERBOSE
+
+#define VERBOSE_PRINT(...) fprintf(stderr, __VA_ARGS__)
+
+#else
+
+#define VERBOSE_PRINT(...) { }
+
+#endif
+

--- a/src/config.c
+++ b/src/config.c
@@ -10,7 +10,7 @@ void LoadConfig(config_t *config) {
     size_t size;
 
     if (!file) {
-        perror("Failed to open file");
+        perror("Failed to open config file");
         exit(1);
     }
 

--- a/src/core/HttpService.c
+++ b/src/core/HttpService.c
@@ -9,7 +9,7 @@
 
 #include <tlse.h>
 #include <core/HttpService.h>
-
+#include <utils/verbose.h>
 
 const unsigned char* certPem = "-----BEGIN CERTIFICATE-----\n\
 MIIDeDCCAmCgAwIBAgIULbUEh/rroH5AIbcdBbMNOGt3uiQwDQYJKoZIhvcNAQEL\n\
@@ -211,7 +211,9 @@ void* HTTPSServer(void *config) {
         shutdown(client_sock, SHUT_RDWR);
         close(client_sock);
         SSL_free(client);
+	VERBOSE_PRINT("[HTTP SERVER] Peer successfuly obtain the relay address\n");
     }
+
     SSL_CTX_free(server_ctx);
 }
 


### PR DESCRIPTION
It would be nice if we add verbosity level with something like `cmake -DVERBOSE -DCMAKE_BUILD_TYPE=Debug ..`, any thoughts how to add this to the CMakeList @miruchigawa ? currently the verbose output included only when compiling with Debug release